### PR TITLE
README.mdのリンク先の変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Convex min-plus convolution を実現するアルゴリズムの実行時間を�
 長さ N の convex な `Vec<i32>` を２本生成して、それらの min-plus convolution を３通りの方法で計算します。
 
 1. `brute`: 定義どおり計算します。(Θ (N²))
-2. `monotone_minima`: [いわゆる monotone minima のアルゴリズム](https://dic.kimiyuki.net/monotone-minima)で計算します。(Θ (N lg N))
-3. `smawk`: [SMAWK アルゴリズム](https://dic.kimiyuki.net/smawk-algorithm)で計算します。(Θ (N))
+2. `monotone_minima`: [いわゆる monotone minima のアルゴリズム](https://noshi91.github.io/algorithm-encyclopedia/monotone-minima)で計算します。(Θ (N lg N))
+3. `smawk`: [SMAWK アルゴリズム](https://noshi91.github.io/algorithm-encyclopedia/smawk-algorithm)で計算します。(Θ (N))
 
 
 Convex なベクターを「ランダムに」生成するとある部分はすべて同じ方法で生成されています。詳しくはコードをご覧いただくとよいのですが、ざっくりいうとたとえば２階差分が一様分布になります。


### PR DESCRIPTION
Kyopro Encyclopedia of Algorithms (ア辞典)へのリンクが切れており、他のサイトへリダイレクトされてしまうため、現在閲覧することのできるnoshi91さんのgithubへのリンクへと変更しました。